### PR TITLE
build: enable to linux/arm64 docker image build

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -1,0 +1,50 @@
+name: push
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - v*
+
+jobs:
+  image-build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Setup Go for binary build
+        uses: actions/setup-go@v3
+        with:
+          go-version: '1.16'
+      - name: Build Binary
+        run: make crossbuild
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          version: latest
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - uses: benjlevesque/short-sha@v1.2
+        id: short-sha
+      - name: Get branch name
+        id: branch-name
+        uses: tj-actions/branch-names@v5.1
+      - name: Set docker tag environment
+        run: |
+          if [ '${{ steps.branch-name.outputs.is_tag }}' == 'true' ]; then
+            tag="${{ steps.branch-name.outputs.tag }}"
+            tag="${tag:1}"
+            echo "DOCKER_IMAGE_TAG=${tag}" >> $GITHUB_ENV
+          elif [ '${{ steps.branch-name.outputs.current_branch }}' == 'main' ]; then
+            echo "DOCKER_IMAGE_TAG=latest" >> $GITHUB_ENV
+          else
+            echo "DOCKER_IMAGE_TAG=${{ steps.branch-name.outputs.current_branch }}" >> $GITHUB_ENV
+          fi
+      - name: Build and push docker image
+        run: make docker-build-push

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@
 !/.travis.yml
 !/.promu.yml
 !/api/v2/openapi.yaml
+!/.github/workflows/*.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
 # use a minimal alpine image
-FROM alpine:3.7
+FROM --platform=$BUILDPLATFORM alpine:3.7
 # add ca-certificates in case you need them
 RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/*
 # set working directory
 
-COPY amtool       /bin/amtool
-COPY alertmanager /bin/alertmanager
+ARG TARGETOS
+ARG TARGETARCH
+COPY .build/${TARGETOS}-${TARGETARCH}/amtool       /bin/amtool
+COPY .build/${TARGETOS}-${TARGETARCH}/alertmanager /bin/alertmanager
 COPY examples/ha/alertmanager.yml      /etc/alertmanager/alertmanager.yml
 
 RUN mkdir -p /alertmanager

--- a/Makefile.common
+++ b/Makefile.common
@@ -101,7 +101,7 @@ endif
 
 PREFIX                  ?= $(shell pwd)/.build/$(GOHOSTOS)-$(GOHOSTARCH)
 BIN_DIR                 ?= $(shell pwd)
-DOCKER_IMAGE_TAG        ?= $(subst /,-,$(shell git rev-parse --abbrev-ref HEAD))
+DOCKER_IMAGE_TAG        ?= latest
 DOCKERFILE_PATH         ?= ./Dockerfile
 DOCKERBUILD_CONTEXT     ?= ./
 DOCKER_REPO             ?= signoz

--- a/Makefile.common
+++ b/Makefile.common
@@ -59,8 +59,9 @@ $(warning Some recipes may not work as expected as the current Go runtime is '$(
 		GOVENDOR := $(FIRST_GOPATH)/bin/govendor
 	endif
 endif
-PROMU        := $(FIRST_GOPATH)/bin/promu
-pkgs          = ./...
+PROMU             := $(FIRST_GOPATH)/bin/promu
+PROMU_TARGETARCHS ?= linux/amd64 linux/arm64
+pkgs               = ./...
 
 ifeq (arm, $(GOHOSTARCH))
 	GOHOSTARM ?= $(shell GOARM= $(GO) env GOARM)
@@ -98,12 +99,12 @@ ifeq ($(GOHOSTOS),$(filter $(GOHOSTOS),linux darwin))
 	endif
 endif
 
-PREFIX                  ?= $(shell pwd)
+PREFIX                  ?= $(shell pwd)/.build/$(GOHOSTOS)-$(GOHOSTARCH)
 BIN_DIR                 ?= $(shell pwd)
 DOCKER_IMAGE_TAG        ?= $(subst /,-,$(shell git rev-parse --abbrev-ref HEAD))
 DOCKERFILE_PATH         ?= ./Dockerfile
 DOCKERBUILD_CONTEXT     ?= ./
-DOCKER_REPO             ?= prom
+DOCKER_REPO             ?= signoz
 
 DOCKER_ARCHS            ?= amd64
 
@@ -241,18 +242,34 @@ common-build: promu
 	@echo ">> building binaries"
 	GO111MODULE=$(GO111MODULE) $(PROMU) build --prefix $(PREFIX) $(PROMU_BINARIES)
 
+.PHONY: common-crossbuild
+common-crossbuild: promu
+	@echo ">> building binaries"
+	GO111MODULE=$(GO111MODULE) $(PROMU) crossbuild $(foreach ARCH,$(PROMU_TARGETARCHS), -p $(ARCH)) $(PROMU_BINARIES)
+
 .PHONY: common-tarball
 common-tarball: promu
 	@echo ">> building release tarball"
 	$(PROMU) tarball --prefix $(PREFIX) $(BIN_DIR)
 
+.PHONY: common-docker-build-push
+common-docker-build-push:
+	docker buildx build \
+		-t "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)" \
+		-f $(DOCKERFILE_PATH) \
+		--no-cache \
+		--push \
+		--platform $(shell echo $(PROMU_TARGETARCHS) | sed "s/ \+/,/g") \
+		$(DOCKERBUILD_CONTEXT)
+
 .PHONY: common-docker $(BUILD_DOCKER_ARCHS)
 common-docker: $(BUILD_DOCKER_ARCHS)
 $(BUILD_DOCKER_ARCHS): common-docker-%:
-	docker build -t "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)-linux-$*:$(DOCKER_IMAGE_TAG)" \
+	docker buildx build \
+		-t "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)-linux-$*:$(DOCKER_IMAGE_TAG)" \
 		-f $(DOCKERFILE_PATH) \
-		--build-arg ARCH="$*" \
-		--build-arg OS="linux" \
+		--load \
+		--platform "linux/$*" \
 		$(DOCKERBUILD_CONTEXT)
 
 .PHONY: common-docker-publish $(PUBLISH_DOCKER_ARCHS)


### PR DESCRIPTION
Support linux/arm64 docker image build.
* adapt Dockerfile to multiplatform build
* add a command for multi-platform binary build 
* add a command for multi-platform Docker build/push 

I have confirmed that the following commands work
* make build
* make crossbuild
* make docker-amd64, make docker-arm64
* make tarball
* make docker-build-push

The test images pushed here, and I confirmed my arm64 image runs on my arm64 machine.
* https://hub.docker.com/r/terakoya76/alertmanager/tags
