### PR TITLE
Add dummy test alert option for email

### DIFF
--- a/api/v1/config_api.go
+++ b/api/v1/config_api.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/notify"
+	"github.com/prometheus/alertmanager/notify/email"
 	"github.com/prometheus/alertmanager/notify/msteams"
 	"github.com/prometheus/alertmanager/notify/opsgenie"
 	"github.com/prometheus/alertmanager/notify/pagerduty"
@@ -289,6 +290,16 @@ func (api *API) testReceiver(w http.ResponseWriter, req *http.Request) {
 			api.respondError(w, apiError{err: err, typ: errorInternal}, "failed to prepare message for select config")
 			return
 		}
+		ctx := getCtx(receiver.Name)
+		dummyAlert := getDummyAlert()
+		_, err = notifier.Notify(ctx, &dummyAlert)
+		if err != nil {
+			api.respondError(w, apiError{err: err, typ: errorInternal}, fmt.Sprintf("failed to send test message to channel (%s)", receiver.Name))
+			return
+		}
+	} else if receiver.EmailConfigs != nil {
+		emailConfig := receiver.EmailConfigs[0]
+		notifier := email.New(emailConfig, tmpl, api.logger)
 		ctx := getCtx(receiver.Name)
 		dummyAlert := getDummyAlert()
 		_, err = notifier.Notify(ctx, &dummyAlert)

--- a/api/v1/config_api.go
+++ b/api/v1/config_api.go
@@ -299,6 +299,11 @@ func (api *API) testReceiver(w http.ResponseWriter, req *http.Request) {
 		}
 	} else if receiver.EmailConfigs != nil {
 		emailConfig := receiver.EmailConfigs[0]
+		emailConfig.From = defaultGlobalConfig.SMTPFrom
+		emailConfig.Smarthost = defaultGlobalConfig.SMTPSmarthost
+		emailConfig.AuthUsername = defaultGlobalConfig.SMTPAuthUsername
+		emailConfig.AuthPassword = defaultGlobalConfig.SMTPAuthPassword
+		emailConfig.RequireTLS = &defaultGlobalConfig.SMTPRequireTLS
 		notifier := email.New(emailConfig, tmpl, api.logger)
 		ctx := getCtx(receiver.Name)
 		dummyAlert := getDummyAlert()

--- a/config/config.go
+++ b/config/config.go
@@ -752,17 +752,26 @@ func DefaultGlobalConfig() GlobalConfig {
 
 	defaultSMTPFrom := constants.GetOrDefaultEnv("ALERTMANAGER_SMTP_FROM", "alertmanager@signoz.io")
 
+	defaultSMTPUsername := constants.GetOrDefaultEnv("ALERTMANAGER_SMTP_AUTH_USERNAME", "")
+	defaultSMTPPassword := constants.GetOrDefaultEnv("ALERTMANAGER_SMTP_AUTH_PASSWORD", "")
+	defaultSMTPAuthSecret := constants.GetOrDefaultEnv("ALERTMANAGER_SMTP_AUTH_SECRET", "")
+	defaultSMTPAuthIdentity := constants.GetOrDefaultEnv("ALERTMANAGER_SMTP_AUTH_IDENTITY", "")
+
 	return GlobalConfig{
-		ResolveTimeout:  resolveTimeout,
-		HTTPConfig:      &defaultHTTPConfig,
-		SMTPSmarthost:   defaultSMTPSmarthost,
-		SMTPFrom:        defaultSMTPFrom,
-		SMTPHello:       "localhost",
-		SMTPRequireTLS:  true,
-		PagerdutyURL:    mustParseURL("https://events.pagerduty.com/v2/enqueue"),
-		OpsGenieAPIURL:  mustParseURL("https://api.opsgenie.com/"),
-		WeChatAPIURL:    mustParseURL("https://qyapi.weixin.qq.com/cgi-bin/"),
-		VictorOpsAPIURL: mustParseURL("https://alert.victorops.com/integrations/generic/20131114/alert/"),
+		ResolveTimeout:   resolveTimeout,
+		HTTPConfig:       &defaultHTTPConfig,
+		SMTPSmarthost:    defaultSMTPSmarthost,
+		SMTPFrom:         defaultSMTPFrom,
+		SMTPAuthUsername: defaultSMTPUsername,
+		SMTPAuthPassword: Secret(defaultSMTPPassword),
+		SMTPAuthSecret:   Secret(defaultSMTPAuthSecret),
+		SMTPAuthIdentity: defaultSMTPAuthIdentity,
+		SMTPHello:        "localhost",
+		SMTPRequireTLS:   true,
+		PagerdutyURL:     mustParseURL("https://events.pagerduty.com/v2/enqueue"),
+		OpsGenieAPIURL:   mustParseURL("https://api.opsgenie.com/"),
+		WeChatAPIURL:     mustParseURL("https://qyapi.weixin.qq.com/cgi-bin/"),
+		VictorOpsAPIURL:  mustParseURL("https://alert.victorops.com/integrations/generic/20131114/alert/"),
 	}
 }
 


### PR DESCRIPTION
- Update global config to use auth details
- Add the ability to send dummy alerts to test the channel

<img width="609" alt="Screenshot 2024-02-26 at 9 44 06 PM" src="https://github.com/SigNoz/alertmanager/assets/22846633/8b5b1cc3-bd6e-4c56-a937-a4485851438c">
